### PR TITLE
Add an empty dependacy array in the animate component's useEffect to prevent reinitializations

### DIFF
--- a/components/animate.tsx
+++ b/components/animate.tsx
@@ -10,7 +10,7 @@ const Animate = () => {
       duration: 1000,
       easing: "ease-out-cubic",
     })
-  })
+  }, [])
 
   return null
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.10",
-        "@types/aos": "^3.0.7",
+        "@types/aos": "^3",
         "autoprefixer": "^10.4.16",
         "postcss": "^8.4.32",
         "tailwindcss": "^3.3.6"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.10",
-    "@types/aos": "^3.0.7",
+    "@types/aos": "^3",
     "autoprefixer": "^10.4.16",
     "postcss": "^8.4.32",
     "tailwindcss": "^3.3.6"


### PR DESCRIPTION
I added an empty dependency array to the useEffect to prevent re-initialization of the AOS library.